### PR TITLE
new switch --precise-output for printing weights with full precision

### DIFF
--- a/tiburon.README
+++ b/tiburon.README
@@ -122,6 +122,10 @@ Usage: tiburon
         be equivalent to a probability between 0.2 and 0.8. This is mostly
         useful for EM training.
 
+  [--precise-output]
+        Print weights with full precision instead of rounded. Only applies to -g
+        and -k.
+
   [--timedebug <time>]
         Print timing information to stderr at a variety of levels: 0+ for total
         operation, 1+ for each processing stage, 2+ for small info


### PR DESCRIPTION
I needed a way to get precise weights for further processing of tiburon’s output.

I think the new flag is generally useful. If you apply a chain of tools, you do not want any unnecessary rounding errors in between.